### PR TITLE
Blocking request handler

### DIFF
--- a/rpc2_test.go
+++ b/rpc2_test.go
@@ -80,6 +80,16 @@ func TestTCPGOB(t *testing.T) {
 		t.Fatal("did not get notification")
 	}
 
+	// Test blocked request
+	clt.SetBlockReq(true)
+	err = clt.Call("add", Args{1, 2}, &rep)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if rep != 3 {
+		t.Fatalf("not expected: %d", rep)
+	}
+
 	// Test undefined method.
 	err = clt.Call("foo", 1, &rep)
 	if err.Error() != "rpc2: can't find method foo" {


### PR DESCRIPTION
In some situation the order of request/response handling is
important. However, in current implementation the order can be
broken: request/response come from same connection can be handled
in random order because request handler is called in a new thread.
This patch provides an option to call the handler in the same
context, to ensure the ordering.