### PR TITLE
fix golangci-lint reports

### DIFF
--- a/client.go
+++ b/client.go
@@ -148,7 +148,9 @@ func (c *Client) handleRequest(req Request, method *handler, argv reflect.Value)
 		Seq:   req.Seq,
 		Error: errmsg,
 	}
-	c.codec.WriteResponse(resp, replyv.Interface())
+	if err := c.codec.WriteResponse(resp, replyv.Interface()); err != nil {
+		debugln("rpc2: error writing response:", err.Error())
+	}
 }
 
 func (c *Client) readRequest(req *Request) error {
@@ -224,7 +226,7 @@ func (c *Client) readResponse(resp *Response) error {
 		call.done()
 	}
 
-	return nil
+	return err
 }
 
 // Close waits for active calls to finish and closes the codec.


### PR DESCRIPTION
Fixed golangci-lint reports:
```bash
$ golangci-lint run .
client.go:151:23: Error return value of `c.codec.WriteResponse` is not checked (errcheck)
        c.codec.WriteResponse(resp, replyv.Interface())
                             ^
client.go:207:4: SA4006: this value of `err` is never used (staticcheck)
                        err = errors.New("reading error body: " + err.Error())
                        ^
client.go:216:4: SA4006: this value of `err` is never used (staticcheck)
                        err = errors.New("reading error body: " + err.Error())
                        ^
```