### PR TITLE
Add go 1.15 and Power Support ppc64le

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,9 @@
 language: go
+
 go:
-  - 1.4
+  - 1.15
   - tip
+  
+arch:
+  - amd64
+  - ppc64le


### PR DESCRIPTION
Added latest go version 1.15 and power support for the travis.yml file with ppc64le. This is part of the Ubuntu distribution for ppc64le. This helps us simplify testing later when distributions are re-building and re-releasing.