### PR TITLE
Support partial unmarshal of parameters

### DIFF
--- a/jsonrpc/jsonrpc.go
+++ b/jsonrpc/jsonrpc.go
@@ -19,6 +19,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"reflect"
 	"sync"
 
 	"github.com/cenkalti/rpc2"
@@ -84,7 +85,7 @@ type serverResponse struct {
 }
 type clientRequest struct {
 	Method string        `json:"method"`
-	Params []interface{} `json:"params"`
+	Params interface{}   `json:"params"`
 	Id     *uint64       `json:"id"`
 }
 
@@ -149,14 +150,21 @@ func (c *jsonCodec) ReadRequestBody(x interface{}) error {
 	if c.serverRequest.Params == nil {
 		return errMissingParams
 	}
-	var params *[]interface{}
-	switch x := x.(type) {
-	case *[]interface{}:
-		params = x
-	default:
-		params = &[]interface{}{x}
+
+	var err error
+
+	// Check if x points to a slice of any kind
+	rt := reflect.TypeOf(x)
+	if rt.Kind() == reflect.Ptr && rt.Elem().Kind() == reflect.Slice {
+		// If it's a slice, unmarshal as is
+		err = json.Unmarshal(*c.serverRequest.Params, x)
+	} else {
+		// Anything else unmarshal into a slice containing x
+		params := &[]interface{}{x}
+		err = json.Unmarshal(*c.serverRequest.Params, params)
 	}
-	return json.Unmarshal(*c.serverRequest.Params, params)
+
+	return err
 }
 
 func (c *jsonCodec) ReadResponseBody(x interface{}) error {
@@ -168,12 +176,16 @@ func (c *jsonCodec) ReadResponseBody(x interface{}) error {
 
 func (c *jsonCodec) WriteRequest(r *rpc2.Request, param interface{}) error {
 	req := &clientRequest{Method: r.Method}
-	switch param := param.(type) {
-	case []interface{}:
+
+	// Check if param is a slice of any kind
+	if reflect.TypeOf(param).Kind() == reflect.Slice {
+		// If it's a slice, leave as is
 		req.Params = param
-	default:
+	} else {
+		// Put anything else into a slice
 		req.Params = []interface{}{param}
 	}
+
 	if r.Seq == 0 {
 		// Notification
 		req.Id = nil


### PR DESCRIPTION
The jsonrpc codec only supports unmarshaling parameters into an
interface{} slice. However, for performance reasons, it might be of
interest to execute a partial unmarshal at any level within the
parameters and delay unmarshaling until a later point in time.

This commit changes ReadRequestBody and WriteRequest to allow
(un)marshaling into any kind of slice so that partial unmarshaling is
supported as well as directly defining the type of slice, if known,
directly in the registered handler.

The following handlers got unmarshal errors from enconding/json before
this change:

func someHandler(client *rpc2.Client, params []json.RawMessage, reply *interface{}) error {}
func someHandler(client *rpc2.Client, params []string, reply *interface{}) error {}

Signed-off-by: Eduardo Ramirez <eduardo.ramirez@hpe.com>