### PR TITLE
Fix panic with nil argument

### DIFF
--- a/jsonrpc/jsonrpc.go
+++ b/jsonrpc/jsonrpc.go
@@ -84,9 +84,9 @@ type serverResponse struct {
 	Error  interface{}      `json:"error"`
 }
 type clientRequest struct {
-	Method string        `json:"method"`
-	Params interface{}   `json:"params"`
-	Id     *uint64       `json:"id"`
+	Method string      `json:"method"`
+	Params interface{} `json:"params"`
+	Id     *uint64     `json:"id"`
 }
 
 func (c *jsonCodec) ReadHeader(req *rpc2.Request, resp *rpc2.Response) error {
@@ -178,7 +178,7 @@ func (c *jsonCodec) WriteRequest(r *rpc2.Request, param interface{}) error {
 	req := &clientRequest{Method: r.Method}
 
 	// Check if param is a slice of any kind
-	if reflect.TypeOf(param).Kind() == reflect.Slice {
+	if param != nil && reflect.TypeOf(param).Kind() == reflect.Slice {
 		// If it's a slice, leave as is
 		req.Params = param
 	} else {

--- a/jsonrpc/jsonrpc_test.go
+++ b/jsonrpc/jsonrpc_test.go
@@ -58,6 +58,14 @@ func TestJSONRPC(t *testing.T) {
 		}
 		return nil
 	})
+	srv.Handle("nilArgs", func(client *rpc2.Client, args []interface{}, reply *[]string) error {
+		for _, v := range args {
+			if v == nil {
+				*reply = append(*reply, "nil")
+			}
+		}
+		return nil
+	})
 	number := make(chan int, 1)
 	srv.Handle("set", func(client *rpc2.Client, i int, _ *struct{}) error {
 		number <- i
@@ -154,6 +162,17 @@ func TestJSONRPC(t *testing.T) {
 	expected = []string{"1", "2"}
 	typedArgs := []int{1, 2}
 	err = clt.Call("typedArgs", typedArgs, &reply)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err = testArgs(expected, reply); err != nil {
+		t.Fatal(err)
+	}
+
+	// Test nil args
+	reply = []string{}
+	expected = []string{"nil"}
+	err = clt.Call("nilArgs", nil, &reply)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Fixes #34

Before PR #33, nil arguments were encapsulated into an []interface{}
slice, however #33 omitted a check for nil and a panic occured.

This commit brings back the previous behavior by properly checking for
nil before testing the params' type. Additionally, a test for the nil
arguments use case is added.

Signed-off-by: Eduardo Ramirez <eduardo.ramirez@hpe.com>