### PR TITLE
Write request into codec asynchronously

### DIFF
--- a/client.go
+++ b/client.go
@@ -341,10 +341,11 @@ func (c *Client) send(ctx context.Context, call *Call) {
 	c.request.Seq = seq
 	c.request.Method = call.Method
 	stop := make(chan struct{})
+	callArgs := call.Args
 	var err error
 	go func() {
 		defer close(stop)
-		err = c.codec.WriteRequest(&c.request, call.Args)
+		err = c.codec.WriteRequest(&c.request, callArgs)
 	}()
 	select {
 	case <-stop:


### PR DESCRIPTION
The c.Go method currently writes request object into channel buffer synchronously which makes the caller to wait indefinitely in case of accidental disconnection of server.
Hence this commit makes to write requests asynchronously so that call object can be returned within specified wait time and caller can decide on what to do with it.