### PR TITLE
fix: skip logging ErrClosed

### DIFF
--- a/server.go
+++ b/server.go
@@ -1,6 +1,7 @@
 package rpc2
 
 import (
+	"errors"
 	"io"
 	"log"
 	"net"
@@ -142,7 +143,9 @@ func (s *Server) Accept(lis net.Listener) {
 	for {
 		conn, err := lis.Accept()
 		if err != nil {
-			log.Print("rpc.Serve: accept:", err.Error())
+			if !errors.Is(err, net.ErrClosed) {
+				log.Print("rpc.Serve: accept:", err.Error())
+			}
 			return
 		}
 		go s.ServeConn(conn)


### PR DESCRIPTION
When using `Accept` with your own listener, it always results in this log.

> rpc.Serve: accept: use of closed network connection