### PR TITLE
Underlying connection getter

### DIFF
--- a/client.go
+++ b/client.go
@@ -363,6 +363,7 @@ func (c *Client) Notify(method string, args interface{}) error {
 	return c.codec.WriteRequest(&c.request, args)
 }
 
+// Conn returns the underlying connection.
 func (c *Client) Conn() io.ReadWriteCloser {
 	return c.codec.Conn()
 }

--- a/client.go
+++ b/client.go
@@ -362,3 +362,7 @@ func (c *Client) Notify(method string, args interface{}) error {
 	c.request.Method = method
 	return c.codec.WriteRequest(&c.request, args)
 }
+
+func (c *Client) Conn() io.ReadWriteCloser {
+	return c.codec.Conn()
+}

--- a/codec.go
+++ b/codec.go
@@ -31,6 +31,8 @@ type Codec interface {
 	// WriteResponse must be safe for concurrent use by multiple goroutines.
 	WriteResponse(*Response, interface{}) error
 
+	Conn() io.ReadWriteCloser
+
 	// Close is called when client/server finished with the connection.
 	Close() error
 }
@@ -118,6 +120,10 @@ func (c *gobCodec) WriteResponse(r *Response, body interface{}) (err error) {
 		return
 	}
 	return c.encBuf.Flush()
+}
+
+func (c *gobCodec) Conn() io.ReadWriteCloser {
+	return c.rwc
 }
 
 func (c *gobCodec) Close() error {

--- a/codec.go
+++ b/codec.go
@@ -31,6 +31,7 @@ type Codec interface {
 	// WriteResponse must be safe for concurrent use by multiple goroutines.
 	WriteResponse(*Response, interface{}) error
 
+	// Conn returns the underlying connection.
 	Conn() io.ReadWriteCloser
 
 	// Close is called when client/server finished with the connection.

--- a/jsonrpc/jsonrpc.go
+++ b/jsonrpc/jsonrpc.go
@@ -4,14 +4,14 @@
 // Use []interface{} as the type of argument when sending and receiving methods.
 //
 // Positional arguments example:
-// 	server.Handle("add", func(client *rpc2.Client, args []interface{}, result *float64) error {
-// 		*result = args[0].(float64) + args[1].(float64)
-// 		return nil
-// 	})
+//
+//	server.Handle("add", func(client *rpc2.Client, args []interface{}, result *float64) error {
+//		*result = args[0].(float64) + args[1].(float64)
+//		return nil
+//	})
 //
 //	var result float64
-// 	client.Call("add", []interface{}{1, 2}, &result)
-//
+//	client.Call("add", []interface{}{1, 2}, &result)
 package jsonrpc
 
 import (
@@ -219,6 +219,10 @@ func (c *jsonCodec) WriteResponse(r *rpc2.Response, x interface{}) error {
 		resp.Error = r.Error
 	}
 	return c.enc.Encode(resp)
+}
+
+func (c *jsonCodec) Conn() io.ReadWriteCloser {
+	return c.c.(io.ReadWriteCloser)
 }
 
 func (c *jsonCodec) Close() error {


### PR DESCRIPTION
Returns the underlying connection.

I personally use this in an OnConnect callback to check some connection properties like the remote address and push them into metadata.
